### PR TITLE
Added error checking in TDauth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,8 @@
 **Disclaimer:** I'm not endorsing and am not affiliated with TD Ameritrade. Be careful using the API and understand that actual orders can be created through this library.  Read and understand the TD Ameritrade's api terms of service and documentation before using.
 
-## Note Version 0.4.3 Changes
-- Added a new client (`TDAClientAuth`) that manages ungoing token requirements.
-- `TDAClientAuth` is just a wrapper around `TDAClient` but includes token renewals as needed
-- `auth::TDauth` was updated to include expire times of tokens
+## Note Version 0.4.4 Changes
+- Added error checking on TDauth module. Used when retrieving tokens.
+- Gave TDAClientAuth acces to TDauth struct
 
 ## Note Version 0.4 Changes
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,4 +2,7 @@
 pub mod account;
 /// type to respresent responses from /userprincipals/ endpoint
 pub mod userprincipals;
+/// type to represent token authorization response from /oauth2/token endpoint
+pub mod token;
+
 //pub mod quote;

--- a/src/model/token.rs
+++ b/src/model/token.rs
@@ -1,0 +1,18 @@
+use serde::Deserialize;
+///
+/// Holds Type Authorization response
+///
+#[derive(Default, Debug, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub token_type: String,
+    pub expires_in: u64,
+    pub scope: String,
+    pub refresh_token_expires_in: u64,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}


### PR DESCRIPTION
Created error checking into `TDauth` struct that holds token authorization.  Now there is an error field in `TDauth` that will hold the last error if token retrieval was unsuccessful. 